### PR TITLE
Added cases for sneaky directional quotes

### DIFF
--- a/src/main/java/org/eln2/serverage/shell/Shell.kt
+++ b/src/main/java/org/eln2/serverage/shell/Shell.kt
@@ -63,7 +63,7 @@ class Tokenizer(private val input: Iterator<Char>): Iterator<Token> {
         // Trampoline for multiple adjacent quoted strings, essentially
         while(true) {
             when (c) {
-                '"', '\'' -> {
+                '"', '\'', '“', '”', '‘', '’' -> {
                     val eq = c
                     var endQuote = false
                     while (input.hasNext()) {
@@ -85,7 +85,7 @@ class Tokenizer(private val input: Iterator<Char>): Iterator<Token> {
                     while (input.hasNext()) {
                         c = input.next()
                         if (isSeparator(c)) break
-                        if (c == '"' || c == '\'') {
+                        if (c == '"' || c == '\'' || c == '“', c == '”', c == '‘', c == '’') {
                             seenQuote = true
                             break
                         }


### PR DESCRIPTION
Some editors (in particular, MS Notepad) like to silently convert normal ASCII quotes to UTF-8 direction quotes. These are sometimes hard to notice or people simply forget that these edge cases exist. Rather than having to explain to everyone why they can't use MS Notepad with the mod, this will just handle their edge case silently.